### PR TITLE
feat: add development lifecycle guidance with stage detection for companion agent

### DIFF
--- a/src/agents/companion.md
+++ b/src/agents/companion.md
@@ -68,6 +68,50 @@ You are not a code generator. You are a thinking partner who happens to be able 
 - Run long autonomous workflows — no multi-step plans executed silently
 - Delegate to other agents — you ARE the hands-on agent
 
+## Development Lifecycle
+
+You guide the human through a structured development lifecycle — not as a gatekeeper, but as a thoughtful partner who knows what good engineering looks like.
+
+### The Stages
+
+| Stage | What happens | Skill to load |
+|-------|-------------|---------------|
+| **DEFINE** | Clarify what we're building — requirements, constraints, edge cases | `spec-driven-development` |
+| **PLAN** | Break work into ordered tasks, identify dependencies, estimate scope | `planning-and-task-breakdown` |
+| **BUILD** | Write code incrementally, test as we go | `incremental-implementation` + `test-driven-development` |
+| **VERIFY** | Debug, investigate failures, confirm behavior matches spec | `debugging-and-error-recovery` |
+| **REVIEW** | Review what was written — quality, security, simplification | `code-review-and-quality` + `code-simplification` |
+| **SHIP** | Pre-launch checks, deployment readiness | `shipping-and-launch` |
+
+### How You Guide
+
+- **Auto-detect** the current stage from conversation context. Confirm with the human: "Sounds like we're defining the spec — want to make sure we nail the requirements before planning?"
+- **Nudge toward the next stage** when the current one feels complete: "We've got a solid spec. Ready to break this into tasks?"
+- **Never block** — if the human wants to jump to BUILD, go with them. But mention what was skipped: "Sure, let's code. Just noting we don't have a spec yet — want to keep it informal or write one as we go?"
+- **Load the stage's skill** when entering a stage — it provides the workflow and quality gates for that stage
+- **Track progress** conversationally — "We've specced it, planned 4 tasks, built 2. Two more to go, then review."
+
+### Stage Signals
+
+Recognize these cues to detect which stage the human is in:
+
+| Cue | Likely stage |
+|-----|-------------|
+| "What should this do?" / "Let's figure out the requirements" | DEFINE |
+| "How should we break this down?" / "What's the order?" | PLAN |
+| "Let's write it" / "Start with the model" / "Next task" | BUILD |
+| "It's not working" / "Why does this fail?" / "Let me test" | VERIFY |
+| "Let's look at what we wrote" / "Any issues?" / "Clean up" | REVIEW |
+| "Ready to deploy" / "Let's ship it" / "Pre-launch check" | SHIP |
+
+### Skipping Stages
+
+Not every change needs every stage. Use judgment:
+
+- **Trivial fix** (typo, config tweak) → BUILD directly, maybe REVIEW
+- **Small feature** → Quick DEFINE + BUILD + REVIEW
+- **Medium+ feature** → Full lifecycle recommended. Nudge accordingly.
+
 ## Skills
 
 Load these skills for project context — they inform your suggestions, not your workflow:
@@ -97,7 +141,8 @@ When a session begins:
 1. Load `telamon.recall_memories` skill to get project context
 2. Ask the human: **"What are we working on today?"**
 3. Explore the relevant area of the codebase together before writing anything
-4. Agree on an approach before touching code
+4. **Detect the starting stage** — is this a new feature (start at DEFINE), a bug (start at VERIFY), or a continuation (pick up where we left off)?
+5. Agree on an approach before touching code
 
 ## Scratch Files
 
@@ -111,6 +156,7 @@ When you need to create a temporary file, use the `telamon.thinking` skill.
 - Match existing codebase patterns — point out which pattern you're following
 - Admit when you're unsure and investigate together
 - Keep the human engaged — this is a conversation, not a monologue
+- Be lifecycle-aware — know which stage you're in and gently guide toward the next one
 
 ## MUST NOT
 

--- a/src/skills/workflow/review_changeset/SKILL.md
+++ b/src/skills/workflow/review_changeset/SKILL.md
@@ -37,6 +37,7 @@ When a class, method, or interface is deleted or renamed:
 When constructor or factory signatures change:
 - Verify all container bindings, registrations, and factories supply the new parameters.
 - Verify variadic/collection parameters are wired, not silently defaulting to empty.
+- Verify new bindings are registered in the component's own ServiceProvider, not in the root AppServiceProvider (unless the binding is cross-cutting). Component encapsulation requires each bounded context to own its wiring.
 
 ### 4. Import Hygiene
 
@@ -61,6 +62,7 @@ For every added or modified test method:
 - If assertions were removed or narrowed (e.g. full-row content comparison reduced to header-only), flag it as a WARNING unless the test's name was also updated to reflect the reduced scope.
 - A test named `amounts_are_converted_using_billing_rate` that no longer asserts anything about amounts or conversion is a BLOCKER — the test name makes a promise the body must keep.
 - Fixture files (`*.csv`, `*.json`, `*.xml`, snapshot files) that are updated in the changeset but are no longer loaded by any test are dead fixtures — flag as WARNING and require deletion or re-use.
+- Verify test classes don't import traits already provided by the base TestCase (e.g. `RefreshDatabase` when base uses `LazilyRefreshDatabase`). Redundant traits can cause subtle behavior changes.
 
 ### 7. Static Analysis Baseline Hygiene
 
@@ -100,6 +102,28 @@ When a `@phpstan-ignore` or `@phpstan-ignore-next-line` comment is added or alre
 - Under `strict_types=1`, passing a `string` where `int` is declared raises a `TypeError` at runtime. Eloquent commonly returns numeric strings for integer columns when the attribute lacks a cast. A callback typed as `fn (int $id)` applied to a plucked integer column is unsafe without a cast — flag as WARNING and suggest `fn (string|int $id): T => new T((int) $id)`.
 - An `@phpstan-ignore` that hides a real type mismatch rather than a PHPStan false positive is a WARNING, not an acceptable suppression.
 
+### 13. Primitive Obsession in Commands & Boundaries
+
+When a command, query, or controller is added or modified:
+- Verify constructor parameters use Value Objects when one exists in the domain (e.g. `UserId` not `int`, `HotelId` not `int`, `Mailbox[]` not `string[]`).
+- Verify controller `authorize()` calls pass VOs to policies, not raw primitives, when the VO is already constructed in the controller.
+- Verify policy methods accept the corresponding VO type, not the primitive.
+- A command accepting a raw primitive when a domain VO exists for that concept is a WARNING.
+
+### 14. Hardcoded Configuration Values
+
+When application or domain layer handlers are added or modified:
+- Flag hardcoded URLs, hostnames, ports, API keys, or environment-dependent strings. These should be injected via constructor + config binding (`giveConfig` or similar).
+- Hardcoded values that vary per environment (dev/staging/prod) are a WARNING — they break deployment flexibility and testability.
+- Pure domain constants (e.g. mathematical formulas, enum values) are not configuration and should remain inline or as class constants.
+
+### 15. Magic Values — Use Class Constants
+
+When a handler, service, or domain class uses literal numbers or strings with domain meaning:
+- Flag inline magic numbers (e.g. TTL durations, retry counts, thresholds) and magic strings (e.g. email subjects, status labels) that should be class constants.
+- Class constants make intent explicit, enable reuse, and simplify testing.
+- A magic value used in more than one place is a WARNING. A single-use magic value with non-obvious meaning is an INFO.
+
 ## Review Report
 
 Save to `<issue-folder>/REVIEW-YYYY-MM-DD-NNN.md`.
@@ -128,6 +152,9 @@ Save to `<issue-folder>/REVIEW-YYYY-MM-DD-NNN.md`.
 > - **Utility Method Abstraction Bypass** — Sibling method state machine not driven into inconsistent state?
 > - **N+1 Query Regression** — Bulk-loads not undermined by remaining per-row lazy loads in the same pipeline (including in called helper methods)?
 > - **`@phpstan-ignore` and Type-Masking** — Suppressions masking real type mismatches (e.g. `string` vs `int` under `strict_types=1`) rather than PHPStan false positives?
+> - **Primitive Obsession** — Commands, queries, and controller authorize calls use VOs when domain VO exists? Policies accept VOs not primitives?
+> - **Hardcoded Configuration** — No hardcoded URLs, hostnames, or environment-dependent values in application/domain handlers?
+> - **Magic Values** — Domain-meaningful literals extracted to class constants?
 > - **Code Style** — Symbols imported? No FQCNs inline? Explicit guards? Sealed/final convention?
 > - **Role Compliance** — All code changes made by the Developer?
 > - **Documentation** — Manual config steps documented? Obsolete steps removed?


### PR DESCRIPTION
## Summary

- Companion now guides the developer through a structured development lifecycle: **DEFINE → PLAN → BUILD → VERIFY → REVIEW → SHIP**
- Each stage maps to Addy Osmani's agent skills (spec-driven-development, planning-and-task-breakdown, incremental-implementation + test-driven-development, debugging-and-error-recovery, code-review-and-quality + code-simplification, shipping-and-launch)
- Companion auto-detects the current stage from conversation cues and gently nudges toward the next stage — never blocks or enforces

## How it works

- **Auto-detection**: Companion reads conversation signals ("What should this do?" → DEFINE, "Let's write it" → BUILD) and confirms with the developer
- **Gentle nudges**: "We've got a solid spec. Ready to break this into tasks?" — suggests, never forces
- **Smart skipping**: Trivial fixes go straight to BUILD; medium+ features get full lifecycle guidance
- **Progress tracking**: Conversational updates on where you are in the lifecycle

Pair-programming DNA fully preserved — the developer always drives.