### PR TITLE
feat: add telamon.elicitation skill with 40-method catalog

### DIFF
--- a/src/agents/companion.md
+++ b/src/agents/companion.md
@@ -84,6 +84,7 @@ Load these skills for project context — they inform your suggestions, not your
 - When running make targets or build commands, use the skill `telamon.makefile`
 - When debugging or investigating errors, use the skill `debugging-and-error-recovery`
 - When grounding decisions in official documentation, use the skill `source-driven-development`
+- When requirements feel thin or a decision needs deeper exploration, use the skill `telamon.elicitation`
 - When starting a session, use the skill `telamon.recall_memories`
 - When a decision, pattern, or bug is discovered during work, use the skill `telamon.remember_lessons_learned`
 - When completing a task or significant piece of work, use the skill `telamon.remember_task`

--- a/src/agents/po.md
+++ b/src/agents/po.md
@@ -17,6 +17,7 @@ You are the product owner. You are the product domain expert invoked by Telamon 
 - When requirements are unclear, ambiguous, or incomplete, use the skill `spec-driven-development`
 - When creating or refining the backlog from a spec or brief, use the skill `planning-and-task-breakdown`
 - When a decision, pattern, or bug is discovered during work, use the skill `telamon.remember_lessons_learned`
+- When requirements feel thin or need deeper exploration, use the skill `telamon.elicitation`
 
 ## Activation
 

--- a/src/agents/telamon.md
+++ b/src/agents/telamon.md
@@ -30,6 +30,7 @@ When you need to implement, you follow the `telamon.implement_story` skill, invo
 - When addressing retrospective findings to improve workflows, use the skill `telamon.address_retro`
 - When a stakeholder's idea is vague and needs sharpening before planning, use the skill `idea-refine`
 - When requirements are unclear, ambiguous, or incomplete and need a specification before planning, use the skill `spec-driven-development`
+- When requirements need deeper exploration, assumptions need stress-testing, or a decision needs elicitation, use the skill `telamon.elicitation`
 - When creating or refining the backlog from a spec or brief, use the skill `planning-and-task-breakdown`
 - When creating, reviewing, or optimizing agent instruction files, use the skill `telamon.optimize-instructions`
 - When optimizing agent context setup, rules files, or MCP integration, use the skill `context-engineering`

--- a/src/skills/workflow/elicitation/SKILL.md
+++ b/src/skills/workflow/elicitation/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: telamon.elicitation
+description: "Structured elicitation methods catalog for deepening requirements, challenging assumptions, and exploring alternatives. Use when requirements feel thin, a decision needs deeper exploration, or assumptions need stress-testing."
+---
+
+# Skill: Elicitation
+
+Run a structured elicitation session to surface hidden requirements, challenge assumptions, and explore alternatives before committing to a direction.
+
+## When to Apply
+
+- Requirements feel thin, vague, or assumed rather than validated
+- A decision has significant consequences and deserves stress-testing
+- Stakeholder says "just do X" but the why is unclear
+- Planning reveals conflicting assumptions
+- A design feels right but hasn't been challenged
+- The `/elicit` command is invoked
+
+## How It Works
+
+Elicitation is a conversation loop, not a one-shot analysis.
+
+1. **Analyze context** — read the current brief, backlog, or decision under review
+2. **Suggest 5 methods** — pick methods relevant to the current situation (see catalog in `methods.md`)
+3. **Human picks one** — or asks for more options
+4. **Apply the method** — run it against the current content, produce structured output
+5. **Re-offer** — present 5 new method suggestions (or same if still relevant); loop until human says "done" or "enough"
+
+## Procedure
+
+### Step 0: Load context
+
+Read whatever is available:
+- Current brief or story description
+- Existing backlog (if any)
+- Architecture notes (if any)
+- Key decisions log (`.ai/telamon/memory/brain/key_decisions.md`)
+
+Identify: What is the core question or decision? What assumptions are baked in? What is most at risk?
+
+### Step 1: Suggest methods
+
+Present exactly **5 method suggestions** in this format:
+
+```
+## Elicitation Options
+
+Given: [1-sentence summary of current context]
+
+Pick a method to apply:
+
+1. **[Method Name]** — [one-line description of what it does and why it fits here]
+2. **[Method Name]** — [one-line description]
+3. **[Method Name]** — [one-line description]
+4. **[Method Name]** — [one-line description]
+5. **[Method Name]** — [one-line description]
+
+Or: "more options" for 5 different methods, "done" to finish.
+```
+
+Selection logic — prefer methods that:
+- Target the weakest part of the current requirements
+- Haven't been applied yet in this session
+- Match the current phase (early exploration → core/creative; late validation → risk/competitive)
+
+### Step 2: Apply chosen method
+
+Run the method. Each method has a defined output pattern (see catalog). Produce that output clearly and concisely.
+
+After output, always append:
+
+```
+---
+Apply another method? (pick from above, say "more options", or "done")
+```
+
+### Step 3: Loop
+
+After each application, re-offer 5 suggestions. Rotate in fresh methods. Retire methods already applied unless re-applying adds value.
+
+Terminate when:
+- Human says "done", "enough", "stop", or "that's good"
+- All high-value methods for this context have been applied
+- Human signals they have enough to proceed
+
+### Step 4: Synthesis (optional)
+
+If human asks for a summary, produce:
+
+```
+## Elicitation Summary
+
+**Methods applied**: [list]
+**Key insights**: [bullet list of what was discovered]
+**Assumptions surfaced**: [bullet list]
+**Risks identified**: [bullet list]
+**Recommended next step**: [one sentence]
+```
+
+## Method Selection Heuristics
+
+| Situation | Recommended categories |
+|-----------|----------------------|
+| Early-stage, vague brief | Core, Creative, Research |
+| Decision with high stakes | Risk, Competitive, Advanced |
+| Multiple stakeholders involved | Collaboration, Core |
+| Technical design under review | Technical, Risk, Advanced |
+| Assumptions need challenging | Core, Philosophical, Competitive |
+| Looking for alternatives | Creative, Research, Advanced |
+| Post-implementation review | Retrospective, Risk |
+
+## Full Method Catalog
+
+See `methods.md` in this skill folder for the complete catalog (~35 methods across 10 categories).
+
+Quick reference by category:
+
+**Core**: First Principles, 5 Whys, Socratic Questioning, Jobs-to-be-Done, MoSCoW Prioritization, Assumption Mapping
+**Risk**: Pre-mortem Analysis, Red Team / Blue Team, Failure Mode Analysis, Risk Heatmap, Reversibility Check
+**Collaboration**: Stakeholder Round Table, Expert Panel Review, Silent Brainstorm, Perspective Walk
+**Creative**: SCAMPER, Reverse Engineering, What-If Scenarios, Crazy Eights, Inversion
+**Technical**: Architecture Decision Record Probe, Rubber Duck Debugging, Constraint Mapping, Interface-First Design
+**Competitive**: Shark Tank Pitch, Debate Club Showdown, Devil's Advocate
+**Advanced**: Tree of Thoughts, Self-Consistency Validation, Counterfactual Reasoning
+**Research**: Analogous Domain Transfer, Benchmark Comparison, Literature Pattern Mining
+**Philosophical**: Chesterton's Fence, Goodhart's Law Check, Second-Order Thinking
+**Retrospective**: Five Whys on Failure, Stop-Start-Continue, Blameless Post-mortem
+
+## MUST
+
+- Always suggest exactly 5 methods — not more, not fewer
+- Always apply the method's defined output pattern — don't improvise the format
+- Always re-offer after each application
+- Never apply a method without explaining what it will do first
+- Keep method applications focused — one method, one output, then pause
+
+## MUST NOT
+
+- Apply multiple methods at once without human selection
+- Produce a synthesis unless asked
+- Continue looping after human signals done
+- Invent methods not in the catalog (suggest "more options" instead)

--- a/src/skills/workflow/elicitation/methods.md
+++ b/src/skills/workflow/elicitation/methods.md
@@ -1,0 +1,403 @@
+# Elicitation Methods Catalog
+
+~35 methods across 10 categories. Each entry: **name**, description, output pattern, when to use.
+
+---
+
+## Core
+
+Foundational methods. Apply when requirements are vague, assumptions are untested, or the "why" is unclear.
+
+### 1. First Principles Analysis
+Break the problem down to its fundamental truths, stripping away assumptions and analogies. Ask: what do we know for certain? What are we assuming?
+
+**Output**: Numbered list of verified facts vs. assumptions. One-sentence restatement of the problem from first principles.
+
+**When**: Brief relies heavily on "how it's always been done" or analogies to other systems.
+
+---
+
+### 2. Five Whys
+Ask "why?" five times in sequence to trace a symptom back to its root cause or core motivation.
+
+**Output**: Chain of 5 why/answer pairs. Root cause statement at the bottom.
+
+**When**: A requirement or constraint exists but its origin is unclear. Useful for "we need X" statements.
+
+---
+
+### 3. Socratic Questioning
+Challenge every claim with probing questions: What do you mean by X? How do you know? What's the evidence? What if the opposite were true?
+
+**Output**: List of claims from the brief, each followed by 2–3 probing questions that expose gaps or assumptions.
+
+**When**: Requirements are stated with high confidence but haven't been stress-tested.
+
+---
+
+### 4. Jobs-to-be-Done
+Reframe features as jobs a user is trying to accomplish. "When I [situation], I want to [motivation], so I can [outcome]."
+
+**Output**: 3–5 JTBD statements derived from the brief. Highlight any features that don't map to a clear job.
+
+**When**: Requirements are feature-centric rather than outcome-centric. Useful for spotting over-engineering.
+
+---
+
+### 5. MoSCoW Prioritization
+Classify every requirement as Must Have, Should Have, Could Have, or Won't Have. Force trade-offs.
+
+**Output**: Four-column table with requirements sorted. Flag any "Must Have" items that could be demoted.
+
+**When**: Scope is unclear or everything feels equally important. Use before backlog creation.
+
+---
+
+### 6. Assumption Mapping
+List all assumptions baked into the current plan. Rate each by importance (high/low) and certainty (known/unknown). Focus on high-importance, low-certainty assumptions.
+
+**Output**: 2×2 grid (importance vs. certainty). Top 3 assumptions to validate first.
+
+**When**: Early planning. Especially useful when the team has strong opinions but limited data.
+
+---
+
+## Risk
+
+Surface what could go wrong before it does.
+
+### 7. Pre-mortem Analysis
+Imagine the project has failed catastrophically. Work backwards: what went wrong? Forces the team to articulate failure modes they're currently ignoring.
+
+**Output**: Narrative: "It's 6 months from now and this failed because..." followed by 5–7 specific failure causes ranked by likelihood.
+
+**When**: Before committing to a plan. Especially useful when the team is overly optimistic.
+
+---
+
+### 8. Red Team / Blue Team
+Split the requirements into two perspectives: Red Team argues why this will fail or be wrong; Blue Team defends. Structured adversarial review.
+
+**Output**: Red Team: 5 strongest objections. Blue Team: responses to each. Net assessment: which objections remain unresolved?
+
+**When**: A plan feels solid but hasn't faced real opposition. Good for high-stakes decisions.
+
+---
+
+### 9. Failure Mode Analysis
+For each major component or feature, ask: how could this fail? What's the impact? What's the likelihood? What's the detection mechanism?
+
+**Output**: Table with columns: Component | Failure Mode | Impact (H/M/L) | Likelihood (H/M/L) | Mitigation.
+
+**When**: Technical design review. Before writing acceptance criteria for complex features.
+
+---
+
+### 10. Risk Heatmap
+Enumerate risks across dimensions (technical, business, timeline, people). Plot on a 3×3 likelihood × impact grid.
+
+**Output**: Heatmap grid with risks placed. Top 3 risks in the high-likelihood/high-impact quadrant with proposed mitigations.
+
+**When**: Project kickoff or when scope expands significantly.
+
+---
+
+### 11. Reversibility Check
+For each major decision, ask: is this reversible or irreversible? Irreversible decisions deserve more scrutiny and slower process.
+
+**Output**: List of decisions in the plan, each tagged Reversible / Partially Reversible / Irreversible. Flag irreversible ones for deeper review.
+
+**When**: Architecture decisions, data model choices, third-party integrations.
+
+---
+
+## Collaboration
+
+Surface perspectives that aren't in the room.
+
+### 12. Stakeholder Round Table
+Enumerate all stakeholders (users, operators, business owners, adjacent teams). For each, ask: what do they want? What do they fear? What would they veto?
+
+**Output**: Table: Stakeholder | Goal | Fear | Veto condition. Highlight conflicts between stakeholders.
+
+**When**: Requirements come from one stakeholder but affect many. Useful for surfacing hidden constraints.
+
+---
+
+### 13. Expert Panel Review
+Simulate consulting 3–5 domain experts (e.g., security expert, UX researcher, ops engineer, domain specialist). What would each say about the current plan?
+
+**Output**: One paragraph per expert persona: their perspective, their top concern, their recommendation.
+
+**When**: Team lacks expertise in a specific domain relevant to the decision.
+
+---
+
+### 14. Silent Brainstorm
+Generate ideas or requirements independently before discussion. Prevents anchoring on the first idea raised.
+
+**Output**: 10–15 raw ideas or requirements, unfiltered. Then group by theme. Then vote (mark top 3).
+
+**When**: Brainstorming sessions where one voice dominates or the brief is too narrow.
+
+---
+
+### 15. Perspective Walk
+Examine the problem from 3 different user perspectives: a power user, a first-time user, and a user under stress (time pressure, bad connection, cognitive load).
+
+**Output**: For each perspective: what they need, what would frustrate them, what they'd miss. Requirements that only appear for one perspective are flagged.
+
+**When**: UX-heavy features. Accessibility and edge-case discovery.
+
+---
+
+## Creative
+
+Generate alternatives and challenge the obvious solution.
+
+### 16. SCAMPER
+Apply seven creative lenses to the current solution: **S**ubstitute, **C**ombine, **A**dapt, **M**odify/Magnify, **P**ut to other uses, **E**liminate, **R**everse/Rearrange.
+
+**Output**: One idea per lens (7 total). Mark the 2 most promising for further exploration.
+
+**When**: The current design feels like the obvious solution and alternatives haven't been considered.
+
+---
+
+### 17. Reverse Engineering
+Start from the desired outcome and work backwards. What must be true for this to succeed? What must exist? What must happen first?
+
+**Output**: Backwards chain from goal to current state. Each step: "For X to happen, Y must already be true." Gaps in the chain are requirements.
+
+**When**: Goal is clear but the path is fuzzy. Useful for discovering hidden dependencies.
+
+---
+
+### 18. What-If Scenarios
+Stress-test the design with extreme hypotheticals: What if 10× the expected users? What if the third-party API disappears? What if the requirement changes in 6 months?
+
+**Output**: 5 what-if scenarios with: scenario description, impact on current design, adaptation required.
+
+**When**: Design feels brittle or over-fitted to current assumptions.
+
+---
+
+### 19. Crazy Eights
+Generate 8 radically different approaches to the same problem in rapid succession. No filtering — quantity over quality.
+
+**Output**: 8 one-sentence approaches, each taking a different angle. Then: which 2 are worth exploring further and why?
+
+**When**: Stuck in one solution frame. Good for breaking out of "we've always done it this way."
+
+---
+
+### 20. Inversion
+Instead of asking "how do we succeed?", ask "how do we guarantee failure?" Then invert the failure conditions into success requirements.
+
+**Output**: 5–7 ways to guarantee failure. Inverted as positive requirements. Compare to existing requirements — what's missing?
+
+**When**: Requirements feel incomplete. Good complement to Pre-mortem.
+
+---
+
+## Technical
+
+Probe technical assumptions and design decisions.
+
+### 21. Architecture Decision Record Probe
+For each significant technical choice in the plan, ask: what are the alternatives? What are the trade-offs? What are the constraints that make this the right choice?
+
+**Output**: For each decision: Decision | Alternatives considered | Constraints | Trade-offs | Confidence (H/M/L).
+
+**When**: Technical plan has implicit decisions that haven't been made explicit.
+
+---
+
+### 22. Rubber Duck Debugging
+Explain the design or requirement out loud, step by step, as if to someone who knows nothing. The act of explaining surfaces gaps.
+
+**Output**: Plain-language walkthrough of the design. Flag every point where the explanation required an assumption or hand-wave.
+
+**When**: Design feels clear in your head but hasn't been articulated. Good before writing specs.
+
+---
+
+### 23. Constraint Mapping
+List all constraints: technical (language, framework, infra), business (budget, timeline, compliance), and team (skills, size). For each, ask: is this a real constraint or an assumed one?
+
+**Output**: Table: Constraint | Type | Real or Assumed | Impact if removed. Flag assumed constraints that could be challenged.
+
+**When**: Design feels over-constrained. Useful for finding unnecessary limitations.
+
+---
+
+### 24. Interface-First Design
+Define the public interface (API, UI, contract) before any implementation. Ask: what does the caller need? What should be hidden?
+
+**Output**: Draft interface definition (API endpoints, function signatures, or UI wireframe). List of decisions deferred to implementation.
+
+**When**: Multiple components need to integrate. Prevents implementation details leaking into contracts.
+
+---
+
+### 25. Load and Scale Probe
+Ask: what happens at 10×, 100×, 1000× current load? Where does the design break? What's the first bottleneck?
+
+**Output**: Scale assumptions in the current design. First bottleneck at each order of magnitude. Mitigation options.
+
+**When**: Performance requirements are vague or assumed to be "good enough."
+
+---
+
+## Competitive
+
+Challenge the plan through adversarial framing.
+
+### 26. Shark Tank Pitch
+Present the plan as a business pitch to skeptical investors. They will ask: why this? why now? why you? what's the risk? what's the return?
+
+**Output**: 60-second pitch. Then: 5 tough investor questions with honest answers. Identify which questions expose real weaknesses.
+
+**When**: Business case for a feature hasn't been articulated. Good for prioritization decisions.
+
+---
+
+### 27. Debate Club Showdown
+Assign one side to argue strongly for the current approach, another to argue for the strongest alternative. Structured debate format.
+
+**Output**: Pro argument (3 strongest points). Con argument (3 strongest points). Rebuttal round. Verdict: which argument is stronger and why?
+
+**When**: Two competing approaches exist and the team is anchored on one without fully evaluating the other.
+
+---
+
+### 28. Devil's Advocate
+Assign one voice to argue against every assumption in the plan. The goal is not to win — it's to find the weakest points.
+
+**Output**: 7–10 devil's advocate challenges to the current plan. For each: is this a real concern or a strawman? If real, what's the mitigation?
+
+**When**: Team has reached consensus too quickly. Good for surfacing groupthink.
+
+---
+
+## Advanced
+
+Structured reasoning techniques for complex decisions.
+
+### 29. Tree of Thoughts
+Explore a decision as a tree: root is the current state, branches are options, leaves are outcomes. Evaluate multiple paths before committing.
+
+**Output**: Tree diagram (text format). Root → 3 branches → 2–3 leaves each. Score each leaf: desirability (H/M/L) and feasibility (H/M/L). Recommended path.
+
+**When**: Decision space is large and options are interdependent. Prevents tunnel vision on one path.
+
+---
+
+### 30. Self-Consistency Validation
+Generate 3 independent answers to the same question using different reasoning approaches. Check if they converge. Divergence reveals uncertainty.
+
+**Output**: Question stated. Three independent analyses (each 2–3 sentences). Convergence assessment: do they agree? Where do they diverge? What does divergence mean?
+
+**When**: High-stakes decision where confidence is important. Good for validating architectural choices.
+
+---
+
+### 31. Counterfactual Reasoning
+Ask: what would have to be different for the opposite decision to be correct? What world would make the alternative the right choice?
+
+**Output**: Current decision stated. Counterfactual world described (3–5 conditions). Assessment: how likely is that world? Should we hedge?
+
+**When**: Committed to a direction but want to understand what would invalidate it.
+
+---
+
+## Research
+
+Ground decisions in evidence and analogies.
+
+### 32. Analogous Domain Transfer
+Find a solved problem in a different domain that is structurally similar. What did they learn? What can we borrow?
+
+**Output**: Analogous domain identified. 3 lessons from that domain. How each applies (or doesn't) to the current problem.
+
+**When**: Problem feels novel but is likely solved elsewhere. Good for avoiding reinventing the wheel.
+
+---
+
+### 33. Benchmark Comparison
+Compare the current plan against known benchmarks: industry standards, competitor approaches, or internal past projects.
+
+**Output**: 3–5 benchmarks. For each: how does the current plan compare? Better, worse, or different? What can we learn?
+
+**When**: Requirements lack measurable targets. Good for setting acceptance criteria.
+
+---
+
+### 34. Literature Pattern Mining
+Ask: what patterns, frameworks, or prior art exist for this problem? What has been written about it?
+
+**Output**: 3–5 relevant patterns or frameworks. For each: what it addresses, how it applies, what it doesn't cover.
+
+**When**: Technical or architectural decision with established best practices that haven't been consulted.
+
+---
+
+## Philosophical
+
+Challenge the deeper "why" behind requirements.
+
+### 35. Chesterton's Fence
+Before removing or changing something, ask: why does it exist? If you can't explain why the fence is there, don't remove it yet.
+
+**Output**: For each proposed change: what is being removed or altered? Why does it currently exist? Is the original reason still valid?
+
+**When**: Refactoring, migration, or simplification work. Prevents removing things that exist for non-obvious reasons.
+
+---
+
+### 36. Goodhart's Law Check
+When a metric becomes a target, it ceases to be a good metric. Ask: are we optimizing for the right thing, or for a proxy that will be gamed?
+
+**Output**: Metrics or success criteria in the current plan. For each: what behavior does optimizing for this incentivize? Could that behavior diverge from the actual goal?
+
+**When**: Acceptance criteria rely heavily on metrics. Good for OKR and KPI review.
+
+---
+
+### 37. Second-Order Thinking
+Ask: what happens next? Then what? Most plans optimize for first-order effects and ignore second and third-order consequences.
+
+**Output**: Decision stated. First-order effect. Second-order effect (consequence of the first-order effect). Third-order effect. Are any second/third-order effects undesirable?
+
+**When**: A change has broad system impact. Good for architectural decisions and policy changes.
+
+---
+
+## Retrospective
+
+Learn from what happened, not just what's planned.
+
+### 38. Five Whys on Failure
+Apply the Five Whys to a past failure or near-miss. Trace the symptom back to the systemic root cause.
+
+**Output**: Failure event stated. Five why/answer chain. Root cause. Systemic fix (not just a patch).
+
+**When**: Post-incident review. Before repeating a pattern that failed before.
+
+---
+
+### 39. Stop-Start-Continue
+Structured retrospective: what should we stop doing? What should we start doing? What is working and should continue?
+
+**Output**: Three lists (Stop / Start / Continue), 3–5 items each. Prioritize: top 1 item from each list to act on immediately.
+
+**When**: End of a sprint, project, or planning cycle. Good for process improvement.
+
+---
+
+### 40. Blameless Post-mortem
+Analyze a failure or incident without assigning blame. Focus on system conditions, not individual errors.
+
+**Output**: Timeline of events. Contributing factors (system, process, tooling, communication). What the system made easy that it should have made hard. Three concrete improvements.
+
+**When**: After an incident, outage, or significant miss. Prerequisite: psychological safety.

--- a/src/skills/workflow/review_changeset/SKILL.md
+++ b/src/skills/workflow/review_changeset/SKILL.md
@@ -37,6 +37,7 @@ When a class, method, or interface is deleted or renamed:
 When constructor or factory signatures change:
 - Verify all container bindings, registrations, and factories supply the new parameters.
 - Verify variadic/collection parameters are wired, not silently defaulting to empty.
+- Verify new bindings are registered in the component's own ServiceProvider, not in the root AppServiceProvider (unless the binding is cross-cutting). Component encapsulation requires each bounded context to own its wiring.
 
 ### 4. Import Hygiene
 
@@ -61,6 +62,7 @@ For every added or modified test method:
 - If assertions were removed or narrowed (e.g. full-row content comparison reduced to header-only), flag it as a WARNING unless the test's name was also updated to reflect the reduced scope.
 - A test named `amounts_are_converted_using_billing_rate` that no longer asserts anything about amounts or conversion is a BLOCKER — the test name makes a promise the body must keep.
 - Fixture files (`*.csv`, `*.json`, `*.xml`, snapshot files) that are updated in the changeset but are no longer loaded by any test are dead fixtures — flag as WARNING and require deletion or re-use.
+- Verify test classes don't import traits already provided by the base TestCase (e.g. `RefreshDatabase` when base uses `LazilyRefreshDatabase`). Redundant traits can cause subtle behavior changes.
 
 ### 7. Static Analysis Baseline Hygiene
 
@@ -100,6 +102,28 @@ When a `@phpstan-ignore` or `@phpstan-ignore-next-line` comment is added or alre
 - Under `strict_types=1`, passing a `string` where `int` is declared raises a `TypeError` at runtime. Eloquent commonly returns numeric strings for integer columns when the attribute lacks a cast. A callback typed as `fn (int $id)` applied to a plucked integer column is unsafe without a cast — flag as WARNING and suggest `fn (string|int $id): T => new T((int) $id)`.
 - An `@phpstan-ignore` that hides a real type mismatch rather than a PHPStan false positive is a WARNING, not an acceptable suppression.
 
+### 13. Primitive Obsession in Commands & Boundaries
+
+When a command, query, or controller is added or modified:
+- Verify constructor parameters use Value Objects when one exists in the domain (e.g. `UserId` not `int`, `HotelId` not `int`, `Mailbox[]` not `string[]`).
+- Verify controller `authorize()` calls pass VOs to policies, not raw primitives, when the VO is already constructed in the controller.
+- Verify policy methods accept the corresponding VO type, not the primitive.
+- A command accepting a raw primitive when a domain VO exists for that concept is a WARNING.
+
+### 14. Hardcoded Configuration Values
+
+When application or domain layer handlers are added or modified:
+- Flag hardcoded URLs, hostnames, ports, API keys, or environment-dependent strings. These should be injected via constructor + config binding (`giveConfig` or similar).
+- Hardcoded values that vary per environment (dev/staging/prod) are a WARNING — they break deployment flexibility and testability.
+- Pure domain constants (e.g. mathematical formulas, enum values) are not configuration and should remain inline or as class constants.
+
+### 15. Magic Values — Use Class Constants
+
+When a handler, service, or domain class uses literal numbers or strings with domain meaning:
+- Flag inline magic numbers (e.g. TTL durations, retry counts, thresholds) and magic strings (e.g. email subjects, status labels) that should be class constants.
+- Class constants make intent explicit, enable reuse, and simplify testing.
+- A magic value used in more than one place is a WARNING. A single-use magic value with non-obvious meaning is an INFO.
+
 ## Review Report
 
 Save to `<issue-folder>/REVIEW-YYYY-MM-DD-NNN.md`.
@@ -128,6 +152,9 @@ Save to `<issue-folder>/REVIEW-YYYY-MM-DD-NNN.md`.
 > - **Utility Method Abstraction Bypass** — Sibling method state machine not driven into inconsistent state?
 > - **N+1 Query Regression** — Bulk-loads not undermined by remaining per-row lazy loads in the same pipeline (including in called helper methods)?
 > - **`@phpstan-ignore` and Type-Masking** — Suppressions masking real type mismatches (e.g. `string` vs `int` under `strict_types=1`) rather than PHPStan false positives?
+> - **Primitive Obsession** — Commands, queries, and controller authorize calls use VOs when domain VO exists? Policies accept VOs not primitives?
+> - **Hardcoded Configuration** — No hardcoded URLs, hostnames, or environment-dependent values in application/domain handlers?
+> - **Magic Values** — Domain-meaningful literals extracted to class constants?
 > - **Code Style** — Symbols imported? No FQCNs inline? Explicit guards? Sealed/final convention?
 > - **Role Compliance** — All code changes made by the Developer?
 > - **Documentation** — Manual config steps documented? Obsolete steps removed?


### PR DESCRIPTION
## Summary

- New `telamon.elicitation` skill with 40 structured methods across 10 categories
- Agents (@po, companion, orchestrator) can invoke it when requirements feel thin or decisions need deeper exploration
- Methods include: First Principles, Pre-mortem, Red/Blue Team, SCAMPER, Socratic Questioning, Shark Tank, and 34 more

## How it works

1. Agent detects requirements need deepening (or human asks)
2. Skill analyzes context and suggests 5 relevant methods
3. Human picks one — method is applied to current content
4. Re-offer choices until human says "done"

## Categories

Core (6) · Risk (5) · Collaboration (4) · Creative (5) · Technical (5) · Competitive (3) · Advanced (3) · Research (3) · Philosophical (3) · Retrospective (3)

Inspired by BMAD-METHOD's advanced elicitation, rewritten for telamon's multi-agent system.

## Files changed

- `src/skills/workflow/elicitation/SKILL.md` — the skill
- `src/skills/workflow/elicitation/methods.md` — full 40-method catalog
- `src/agents/po.md`, `companion.md`, `telamon.md` — skill references