### PR TITLE
fix: prevent pipefail exit when TELAMON_SUBMODULES is absent from .env

### DIFF
--- a/bin/update.sh
+++ b/bin/update.sh
@@ -97,7 +97,7 @@ done
 # ── User submodules ───────────────────────────────────────────────────────────
 header "User submodules"
 
-_raw_submodules="$(grep -s '^TELAMON_SUBMODULES=' "${TELAMON_ROOT}/.env" | head -1 | cut -d= -f2- | tr -d "\"'")"
+_raw_submodules="$(grep -s '^TELAMON_SUBMODULES=' "${TELAMON_ROOT}/.env" | head -1 | cut -d= -f2- | tr -d "\"'" || true)"
 
 if [[ -z "${_raw_submodules}" ]]; then
   skip "no user submodules configured"


### PR DESCRIPTION
## Problem

`telamon update` always exits with error code 1 at the "User submodules" step, even when no user submodules are configured.

## Root Cause

Line 100 in `bin/update.sh`:
```bash
_raw_submodules="$(grep -s '^TELAMON_SUBMODULES=' "${TELAMON_ROOT}/.env" | ...)"
```

`grep -s` returns exit code 1 when no match is found. With `set -euo pipefail`, this kills the entire script.

## Fix

Added `|| true` to the pipeline so a missing key produces an empty string instead of a fatal error.